### PR TITLE
Update base-images.mk

### DIFF
--- a/mirror/docker/base-images.mk
+++ b/mirror/docker/base-images.mk
@@ -1,4 +1,4 @@
-BASE_IMAGE_FILES:=centos.tar.xz busybox.tar.xz
+BASE_IMAGE_FILES:=fuel-centos.tar.xz busybox.tar.xz
 
 # docker base image files
 $(addprefix $(LOCAL_MIRROR_DOCKER_BASEURL)/,$(BASE_IMAGE_FILES)):


### PR DESCRIPTION
The file name should be fuel-centos.tar.xz, refers to the repository name: 
http://mirror.fuel-infra.org/fwm/6.0-icehouse/docker/