### PR TITLE
Stable/6.0

### DIFF
--- a/mirror/centos/repo.mk
+++ b/mirror/centos/repo.mk
@@ -65,7 +65,7 @@ $(BUILD_DIR)/mirror/centos/yum.done: \
 	test `grep "conflicts with" $(BUILD_DIR)/mirror/centos/yumdownloader.log | grep -v '^[[:space:]]' | wc -l` -le 9
 	# Yumdownloader workaround number four:
 	# yumdownloader should fail if some errors appears
-	test `grep "Errno" $(BUILD_DIR)/mirror/centos/yumdownloader.log | wc -l` = 0
+	test `grep "Errno" $(BUILD_DIR)/mirror/centos/yumdownloader.log | grep -Ev "perl\(Error\)|perl-Error" | wc -l` = 0
 	$(ACTION.TOUCH)
 
 show-yum-urls-centos: \

--- a/utils/simple_http_daemon.py
+++ b/utils/simple_http_daemon.py
@@ -64,5 +64,10 @@ if __name__ == "__main__":
     else:
         pid = '/var/run/simplehttpd.pid'
 
-    server = SimpleHTTPDaemon('0.0.0.0', port, pid, 600)
+    if sys.argv[3:]:
+        timeout = int(sys.argv[3])
+    else:
+        timeout = sys.maxint
+
+    server = SimpleHTTPDaemon('0.0.0.0', port, pid, timeout)
     server.start()


### PR DESCRIPTION
Dear Maintainer,

This is Wei Tang, from China, you can also call me Tonny. I am a fresh man about FUEL, so if there is anything wrong, please guide me.

Now I am trying to build the ISO from FUEL 6.0 source code myself in Ubuntu 12.04.5, but I met several problems which really blocked me for a while. After some efforts, I think I can give the solution and build the ISO sucessfully. So maybe you can consider accept my code changes this time.

1）errro report from the RPM error check code
In my environment ( ubuntu 12.04.5 )，when do download the requirment RPMS, the dependency RPM perl-Error-0.17015-4.el6.noarch will also be downloaded and recorded in the log file. Since the error check code will just give a judgement based on the key word "Error" in the log file,  this would result in error report and block the ISO build process later.

2）intermittent http error from the http server
In the original code, we configure and start a http server as RPM repository. However the configure parameters are fixed and lack inflexibility, this would result in RPM download random error and blocking the ISO build process. For example, if I build the ISO in ubuntu 12.04.5 virtualbox vm, it will always fail at a random download step.